### PR TITLE
[Bug-Fix] Compatibility With Android 11

### DIFF
--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
+    <queries>
+        <package android:name="io.shoonya.shoonyadpc" />
+    </queries>
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
+    <!-- (For Android 11 and above) To enable the package visibility of Esper Agent -->
     <queries>
         <package android:name="io.shoonya.shoonyadpc" />
     </queries>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
         constraint_layout_version = "2.0.4"
 
-        esper_sdk_version = "2.0.8604.14"
+        esper_sdk_version = "2.1.2851.18"
 
         gradle_version = "4.2.1"
 


### PR DESCRIPTION
### Problem
In Android 11, even when Esper Agent is installed, then also Esper SDK is throwing `EsperSDKNotFoundException`.

### Solution Explanation
In Android 11, the package discovery was narrowed down and due to this the `Package Manager` was not able to find the Esper Agent (dpc) for the given package name (io.shoonya.shoonyadpc).

To fix this, added the query in the `AndroidManifest.xml` file to enable `Package Manager` to be able find the Esper Agent.